### PR TITLE
Fixed a bug with exp when jitter was true delay would be 0 or 1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# -*- mode: ini-generic -*-
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -60,13 +60,18 @@ You can provide any function you want, including async. The `Error` is provided 
 
 ```js
 // this is the default - a fully randomized, truncated exponential value
-dread.exp({ 
+dread.exp({
     base: Number(100),
     factor: Number(2),
     limit: Number(10000),
-    jitter: Boolean(true)
+    jitter: JitterType.FULL
 });
 ```
+`jitter` may be one of:
+
+- `JitterType.NONE` the full backoff value is used
+- `JitterType.FULL` a randomized value between 0 and the full backoff
+- `JitterType.HALF` a randomized valued between full backoff / 2 and full backoff
 
 ### timeout
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dread",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dread",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "yet another retry library",
   "main": "dread.js",
   "scripts": {


### PR DESCRIPTION
Fixed a bug with exp when jitter was true the delay would always be 0 or 1. Added some tests to verify the fix and my assumptions about the intended behaviour(let me know if they weren't correct).